### PR TITLE
Bump marketplace-integration-base version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /home/gradle/src
 RUN --mount=type=cache,target=/home/gradle/.gradle gradle --parallel -S --no-daemon distTar
 
 ## Build production image with only outputs
-FROM quay.io/beekeeper/integration-connector-base:0.1.1
+FROM quay.io/beekeeper/integration-connector-base:0.3.0
 
 LABEL Description="Sample Shift Sync Connector"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 sdkVersion=0.3.0
 jacksonVersion=2.10.3
-dropwizardVersion=1.3.19

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-sdkVersion=0.1.1
+sdkVersion=0.3.0
 jacksonVersion=2.10.3
 dropwizardVersion=1.3.19


### PR DESCRIPTION
Bump marketplace-integration-base image version to the latest. 
Remove dropwizard version from gradle.properties as it is not used in dependencies. Dropwizard libraries are taken from integration-base image. 