### PR TITLE
Update shiftsync project dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.0-experimental
-# Build with multistage build on jdk-11
-FROM gradle:6.3.0-jdk11 as java_build
+# Build with multistage build on jdk-17
+FROM gradle:7.6.0-jdk17 as java_build
 
 COPY --chown=gradle:gradle . /home/gradle/src
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # marketplace-connector-shiftsync-sample
 Sample Shift Sync Connector
 
-TODO: write a nice readme and link connector documentation here once it's done 
+TODO: write a nice readme and link connector documentation here once it's done.

--- a/build.gradle
+++ b/build.gradle
@@ -29,19 +29,4 @@ subprojects {
         maven { url "https://clojars.org/repo" }
         maven { url 'https://s3-eu-west-1.amazonaws.com/beekeeper-marketplace-sdk/maven2/release/' }
     }
-
-    dependencyCheck {
-        skipConfigurations = [
-                'spotbugs'
-        ]
-    }
-
-    pluginManager.withPlugin('com.github.spotbugs') {
-        spotbugs {
-            toolVersion = '4.8.3'
-        }
-        tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
-            enabled = false
-        }
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id 'io.franzbecker.gradle-lombok' version '3.3.0'
+    id 'io.franzbecker.gradle-lombok' version '5.0.0'
     id 'io.beekeeper.gradle.plugin' version '0.9.24'
 }
 
@@ -18,6 +18,10 @@ subprojects {
     version '0.0.1'
 
     apply plugin: 'io.franzbecker.gradle-lombok'
+
+    lombok {
+        version = '1.18.30'
+    }
 
     repositories {
         mavenLocal()
@@ -30,5 +34,14 @@ subprojects {
         skipConfigurations = [
                 'spotbugs'
         ]
+    }
+
+    pluginManager.withPlugin('com.github.spotbugs') {
+        spotbugs {
+            toolVersion = '4.8.3'
+        }
+        tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
+            enabled = false
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 sdkVersion=0.7.1
-jacksonVersion=2.13.2
+jacksonVersion=2.18.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue May 19 10:11:52 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/shiftsync-sample/build.gradle
+++ b/shiftsync-sample/build.gradle
@@ -8,8 +8,11 @@ targetCompatibility = 17
 
 apply plugin: 'io.beekeeper.integration.connector'
 
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
+    enabled = false
+}
+
 dependencies {
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.6'
 
     implementation "io.beekeeper:connector-shift-sync-api:${sdkVersion}"
 

--- a/shiftsync-sample/build.gradle
+++ b/shiftsync-sample/build.gradle
@@ -3,13 +3,13 @@ plugins {
     id 'maven-publish'
 }
 
-sourceCompatibility = 1.11
-targetCompatibility = 1.11
+sourceCompatibility = 17
+targetCompatibility = 17
 
 apply plugin: 'io.beekeeper.integration.connector'
 
 dependencies {
-    compileOnly 'com.google.code.findbugs:annotations:3.0.1'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.6'
 
     implementation "io.beekeeper:connector-shift-sync-api:${sdkVersion}"
 
@@ -19,9 +19,9 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
 
     implementation 'org.apache.commons:commons-lang3:3.10'
-    implementation 'com.squareup.okhttp3:okhttp:4.7.2'
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation group: 'com.squareup.retrofit2', name: 'converter-jackson', version: '2.9.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.11.0'
+    implementation group: 'com.squareup.retrofit2', name: 'converter-jackson', version: '2.11.0'
 
     /*************************************************************/
     // make this run > jdk9


### PR DESCRIPTION
- upgrade 
  - JDK `11` -> `17`
  - gradle `6.3.0-jdk11` -> `7.6.0-jdk17`
  - okhttp `4.7.2` -> `4.12.0`
  - retrofit `2.9.0` -> `2.11.0`
  - jackson `2.12.3` -> `2.18.2`
  - gradle-lombok `3.3.0` -> `5.0.0`

- change
  - findbugs (deprecated) -> remove
  - spotbugs - remove from implicit dependencies